### PR TITLE
[fix] Install checkfile binary to builder images

### DIFF
--- a/builder-image/apache/Makefile
+++ b/builder-image/apache/Makefile
@@ -4,11 +4,11 @@ VERSION  := 2.4
 
 URL = $(REGISTRY)/$(IMAGE):$(VERSION)
 
-
 .PHONY: all build push
 all: build push
 
 build:
+	patch -d ./httpd-container -p0 < tmaxcloud.patch
 	docker build -t $(URL) -f ./httpd-container/2.4/Dockerfile ./httpd-container/2.4/
 
 push:

--- a/builder-image/apache/tmaxcloud.patch
+++ b/builder-image/apache/tmaxcloud.patch
@@ -1,0 +1,15 @@
+diff --git 2.4/Dockerfile 2.4/Dockerfile
+index e752274..3de3f01 100644
+--- 2.4/Dockerfile
++++ 2.4/Dockerfile
+@@ -65,6 +65,10 @@ COPY ./root /
+ # Reset permissions of filesystem to default values
+ RUN /usr/libexec/httpd-prepare && rpm-file-permissions
+ 
++# Tmax-cloud - install checkfile
++RUN curl -L -s -o /usr/bin/checkfile https://github.com/cqbqdd11519/checkfile/releases/download/v0.0.1/checkfile && \
++    chmod +x /usr/bin/checkfile
++
+ USER 1001
+ 
+ # Not using VOLUME statement since it's not working in OpenShift Online:

--- a/builder-image/django/Dockerfile
+++ b/builder-image/django/Dockerfile
@@ -1,0 +1,7 @@
+FROM centos/python-35-centos7
+
+USER root
+# Tmax-cloud - install checkfile
+RUN curl -L -s -o /usr/bin/checkfile https://github.com/cqbqdd11519/checkfile/releases/download/v0.0.1/checkfile && \
+    chmod +x /usr/bin/checkfile
+USER 1001

--- a/builder-image/django/Makefile
+++ b/builder-image/django/Makefile
@@ -4,14 +4,11 @@ VERSION  := 35
 
 URL = $(REGISTRY)/$(IMAGE):$(VERSION)
 
-ORIGINAL = centos/python-35-centos7
-
 .PHONY: all build push
 all: build push
 
 build:
-	docker pull $(ORIGINAL)
-	docker tag $(ORIGINAL) $(URL)
+	docker build -t $(URL) -f ./Dockerfile .
 
 push:
 	docker push $(URL)

--- a/builder-image/nodejs/Dockerfile
+++ b/builder-image/nodejs/Dockerfile
@@ -1,0 +1,7 @@
+FROM centos/nodejs-12-centos7
+
+USER root
+# Tmax-cloud - install checkfile
+RUN curl -L -s -o /usr/bin/checkfile https://github.com/cqbqdd11519/checkfile/releases/download/v0.0.1/checkfile && \
+    chmod +x /usr/bin/checkfile
+USER 1001

--- a/builder-image/nodejs/Makefile
+++ b/builder-image/nodejs/Makefile
@@ -4,14 +4,11 @@ VERSION  := 12
 
 URL = $(REGISTRY)/$(IMAGE):$(VERSION)
 
-ORIGINAL = centos/nodejs-12-centos7
-
 .PHONY: all build push
 all: build push
 
 build:
-	docker pull $(ORIGINAL)
-	docker tag $(ORIGINAL) $(URL)
+	docker build -t $(URL) -f ./Dockerfile .
 
 push:
 	docker push $(URL)

--- a/builder-image/tomcat/tmaxcloud.patch
+++ b/builder-image/tomcat/tmaxcloud.patch
@@ -1,5 +1,5 @@
 diff --git tomcat-8.5/maven-3.5.0/jdk-8/Dockerfile tomcat-8.5/maven-3.5.0/jdk-8/Dockerfile
-index c9161e7..3834da9 100644
+index c9161e7..6e83113 100644
 --- tomcat-8.5/maven-3.5.0/jdk-8/Dockerfile
 +++ tomcat-8.5/maven-3.5.0/jdk-8/Dockerfile
 @@ -7,14 +7,15 @@ MAINTAINER Sarcouy <sarcouy@protonmail.com>
@@ -18,7 +18,7 @@ index c9161e7..3834da9 100644
 -    POM_PATH=.
 +    POM_PATH=. \
 +    MVN_CENTRAL_URL=https://repo1.maven.org/maven2
-
+ 
  LABEL io.k8s.description="Platform for building and running Java applications on Apache-Tomcat 8.5.14" \
        io.k8s.display-name="Apache-Tomcat 8.5.14" \
 @@ -27,12 +28,12 @@ RUN INSTALL_PKGS="tar unzip bc which lsof $JAVA" && \
@@ -34,19 +34,23 @@ index c9161e7..3834da9 100644
 -    (curl -v https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz | tar -zx --strip-components=1 -C /tomcat) && \
 +    (curl -L -v https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz | tar -zx --strip-components=1 -C /tomcat) && \
      mkdir -p /opt/s2i/destination
-
+ 
  # Add s2i tomcat customizations
-@@ -43,7 +44,9 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
-
+@@ -43,7 +44,13 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+ 
  RUN chown -R 1001:0 /tomcat && chown -R 1001:0 $HOME && \
      chmod -R ug+rwx /tomcat && \
 -    chmod -R g+rw /opt/s2i/destination
 +    chmod -R g+rw /opt/s2i/destination && \
 +    chown -R 1001:0 /opt/app-root/src/.m2/settings.xml && \
 +    rm -rf /tomcat/webapps/ROOT
-
++
++# Tmax-cloud - install checkfile
++RUN curl -L -s -o /usr/bin/checkfile https://github.com/cqbqdd11519/checkfile/releases/download/v0.0.1/checkfile && \
++    chmod +x /usr/bin/checkfile
+ 
  USER 1001
-
+ 
 diff --git tomcat-8.5/maven-3.5.0/jdk-8/contrib/settings.xml tomcat-8.5/maven-3.5.0/jdk-8/contrib/settings.xml
 index e17a1d9..8e70292 100644
 --- tomcat-8.5/maven-3.5.0/jdk-8/contrib/settings.xml

--- a/builder-image/wildfly/Dockerfile
+++ b/builder-image/wildfly/Dockerfile
@@ -6,4 +6,7 @@ USER root
 COPY assemble /usr/libexec/s2i/assemble
 COPY settings.xml /home/jboss/.m2/settings.xml
 RUN chown jboss:root /home/jboss/.m2/settings.xml
+# Tmax-cloud - install checkfile
+RUN curl -L -s -o /usr/bin/checkfile https://github.com/cqbqdd11519/checkfile/releases/download/v0.0.1/checkfile && \
+    chmod +x /usr/bin/checkfile
 USER jboss


### PR DESCRIPTION
checkfile will be used for verifying that specific files are intact
during the container run